### PR TITLE
Typed scheme test name conflicts 

### DIFF
--- a/test/typed/SchemeTyped.agda
+++ b/test/typed/SchemeTyped.agda
@@ -1,5 +1,5 @@
 -- compilation of λ□ type schemes
-module Scheme where
+module SchemeTyped where
 
 open import Agda.Builtin.List
 open import Agda.Builtin.Nat


### PR DESCRIPTION
Typed scheme test appears to be conflicting with the untyped scheme test on case-insensitive systems.